### PR TITLE
Update cli.py, fixes vast-data/vastpy#4

### DIFF
--- a/vastpy/cli.py
+++ b/vastpy/cli.py
@@ -14,6 +14,8 @@ def key_value_pair(s):
 def pairs_to_multidict(l):
     result = {}
     for key, value in l:
+        if value == "null":
+            value = None
         if key in result:
             if isinstance(result[key], list):
                 result[key].append(value)


### PR DESCRIPTION
Added support for explicit null to None conversion.

Success in creating vip pool with all_tenant

```
(test) (base) udit.raj@Udits-MacBook-Pro vastpy % python ./cli.py --user admin --password 123456 --address 10.27.200.208 post vippools name=bg-test start_ip="172.16.204.39" end_ip="172.16.204.40" subnet_cidr=16 role=PROTOCOLS tenant_id="null"
id |guid                                 |name    |url                                    |title                         |start_ip      |end_ip        |vlan |subnet_cidr |gw_ip |cluster     |cluster_id |active_cnode_ids |gw_ipv6 |subnet_cidr_ipv6 |tenant_id |cnode_ids |cnodes |domain_name |role      |ip_ranges                            |ranges_summary     |sync   |sync_time                   |vms_preferred |enabled |port_membership |active_interfaces |enable_l3 |vast_asn |peer_asn |tenant_name |enable_weighted_balancing 
---+-------------------------------------+--------+---------------------------------------+------------------------------+--------------+--------------+-----+------------+------+------------+-----------+-----------------+--------+-----------------+----------+----------+-------+------------+----------+-------------------------------------+-------------------+-------+----------------------------+--------------+--------+----------------+------------------+----------+---------+---------+------------+--------------------------+
38 |17379882-a6b6-402c-ba28-342e5d2fa5a5 |bg-test |https://10.27.200.208/api/vippools/38/ |172.16.204.39 - 172.16.204.40 |172.16.204.39 |172.16.204.40 |0    |16          |      |vast208-kfs |1          |[]               |        |None             |None      |[]        |[]     |            |PROTOCOLS |[['172.16.204.39', '172.16.204.40']] |172.16.204.[39-40] |SYNCED |2025-02-07T08:58:52.972457Z |False         |True    |ALL             |0                 |False     |0        |0        |None        |False 
```
![image_2025-02-07_143049523](https://github.com/user-attachments/assets/10cb62b8-40f4-41a4-97eb-00aec529a7e7)

