### PR TITLE
Api versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "vastpy"
-version = "0.3.11"
+version = "0.3.12"
 description = ""
 authors = ["Alon Horev <alon@vastdata.com>"]
 readme = "README.md"

--- a/vastpy/__init__.py
+++ b/vastpy/__init__.py
@@ -22,7 +22,7 @@ SUCCESS_CODES = {http.HTTPStatus.OK,
                  http.HTTPStatus.PARTIAL_CONTENT}
 
 class VASTClient(object):
-    def __init__(self, user=None, password=None, address=None, url='api', cert_file=None, cert_server_name=None, tenant=None, token=None):
+    def __init__(self, user=None, password=None, address=None, url='api', cert_file=None, cert_server_name=None, tenant=None, token=None, version=None):
         self._user = user
         self._password = password
         self._tenant = tenant
@@ -31,6 +31,7 @@ class VASTClient(object):
         self._cert_file = cert_file
         self._cert_server_name = cert_server_name
         self._url = url
+        self._version = version
         has_token = self._token is not None 
         has_userpass = (self._user is not None or self._password is not None)
 
@@ -45,14 +46,16 @@ class VASTClient(object):
         return self[part]
 
     def __getitem__(self, part):
+        version_path = f'/{self._version}' if self._version else ''
         return self.__class__(user=self._user,
                               password=self._password,
                               address=self._address,
                               cert_file=self._cert_file,
                               cert_server_name=self._cert_server_name,
-                              url=f'{self._url}/{part}',
+                              url=f'{self._url}{version_path}/{part}',
                               tenant=self._tenant,
-                              token=self._token)
+                              token=self._token,
+                              version=self._version)
 
     def __repr__(self):
         return f'VASTClient(address="{self._address}", url="{self._url}")'
@@ -80,7 +83,8 @@ class VASTClient(object):
                 else:
                     result.append((k, v))
             fields = result
-        r = pm.request(method, f'https://{self._address}/{self._url}/', headers=headers, fields=fields, body=data)
+        version_path = f'/{self._version}' if self._version else ''
+        r = pm.request(method, f'https://{self._address}/{self._url}{version_path}/', headers=headers, fields=fields, body=data)
         if r.status not in SUCCESS_CODES:
             raise RESTFailure(method, self._url, fields, r.status, r.data)
         data = r.data

--- a/vastpy/cli.py
+++ b/vastpy/cli.py
@@ -105,6 +105,7 @@ def prepare_parser():
     add_argument('VMS_TOKEN', '--token', help='VMS API Token')
     add_argument('VMS_CERT_FILE', '--cert-file', help='Path to custom SSL certificate for VMS')
     add_argument('VMS_CERT_SERVER', '--cert-server-name', help='Address of custom SSL certificate authority')
+    add_argument('VMS_API_VERSION', '--api-version', help='API version')
     parser.add_argument('--json', action='store_true')
     parser.add_argument('-i', '--file-input', help='JSON file with as body for POST/PATCH operations')
     parser.add_argument('operation', type=str, choices=OPERATIONS)
@@ -120,7 +121,8 @@ def main():
                         cert_file=args.cert_file,
                         cert_server_name=args.cert_server_name,
                         tenant=args.tenant_name,
-                        token=args.token)
+                        token=args.token,
+                        version=args.api_version)
     method = getattr(client[args.endpoint], args.operation)
 
     params = {}


### PR DESCRIPTION
added support in API versions - api version is now a field in the VASTClient object. The default remains the oldest version.
Testing results -
Vastpy - 
![image](https://github.com/user-attachments/assets/cc2b3ae6-a87a-42de-84f8-a80b2dc98e27)
Vastpy-cli -
<img width="1721" alt="image" src="https://github.com/user-attachments/assets/01013778-ffec-4e41-bfd2-0b544b4f5706" />
<img width="1726" alt="image" src="https://github.com/user-attachments/assets/b039d36e-a497-4c96-af18-fceb73af0a6b" />
